### PR TITLE
result buffer calculation aligned with typescript solution. 1mb testcase

### DIFF
--- a/tests/test_asherah.py
+++ b/tests/test_asherah.py
@@ -35,3 +35,9 @@ class AsherahTest(TestCase):
         encrypted = self.asherah.encrypt("partition", data)
         decrypted = self.asherah.decrypt("partition", encrypted)
         self.assertEqual(decrypted, data)
+
+    def test_encrypt_decrypt_large_data(self):
+        data = b"a" * 1024 * 1024
+        encrypted = self.asherah.encrypt("partition", data)
+        decrypted = self.asherah.decrypt("partition", encrypted)
+        self.assertEqual(decrypted, data)


### PR DESCRIPTION
Previously attempts to encrypt larger pieces of data received a -3 error "EncryptToJson: JsonToBuffer: Output buffer needed XXX bytes". This change uses the same method as the [typescript version](https://github.com/godaddy/asherah-node/blob/v1.1.1/src/asherah.ts) to better estimate response size